### PR TITLE
fix(ci): keep custom image tags separate and add ARM64

### DIFF
--- a/.github/workflows/build-custom-image.yml
+++ b/.github/workflows/build-custom-image.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v3.6.0
+
       - name: Set up BuildKit
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v3.11.1
 
@@ -37,13 +40,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Read project version
-        id: version
-        shell: bash
-        run: |
-          version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-
       - name: Extract image metadata
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v5.8.0
@@ -52,7 +48,6 @@ jobs:
           tags: |
             type=raw,value=latest
             type=raw,value=custom-latest
-            type=raw,value=${{ steps.version.outputs.version }}
             type=sha,prefix=
 
       - name: Build and publish
@@ -60,6 +55,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Summary

- build the rolling custom image for `linux/amd64` and `linux/arm64` using QEMU
- stop the custom workflow from publishing the project version tag, leaving semver tags owned by the release workflow

This prevents rolling builds from overwriting release images and keeps `latest`/`custom-latest` usable on ARM64.

Fixes #11